### PR TITLE
Make variables used in README example consistent so example works

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,36 +31,36 @@ var options = {
 }
 
 //start a new PDF doc
-var doc = new PDFDocument(options)
+var pdfDoc = new PDFDocument(options)
 var stream = fs.createWriteStream('output.pdf')
-doc.pipe(stream)
+pdfDoc.pipe(stream)
 
 // Open up the image file in sharp
-sharp(fs.readFileSync(imageFile))
-  .rotate(newFile.rotation)
+sharp(image)
+  .rotate(hocrObj.rotation)
   .toBuffer(function(err, data, info) {
     if (err) { throw err }
-  
+
     // this allows doing manipulations of the image before inserting it into the PDF document
-  
+
     // generate the words
     var words = hocrObj.getWords()
     for (var x = 0; x < words.length; x++) {
       // use height of bbox
-      hocrObj.fontSize(words[x][3])
-      hocrObj.font('Helvetica')
-      hocrObj.fillColor('black')
-      hocrObj.text(words[x][4], words[x][0], words[x][1]), {
+      pdfDoc.fontSize(words[x][3])
+      pdfDoc.font('Helvetica')
+      pdfDoc.fillColor('black')
+      pdfDoc.text(words[x][4], words[x][0], words[x][1]), {
         width: words[x][2],
         height: words[x][3],
         aligh: 'centre'
       }
     }
-    
+
     // optional: draw bounding boxes around paragraphs and/or words
-    var wordboxes = newFile.drawWordBoxes()
+    var wordboxes = hocrObj.drawWordBoxes()
     for (var w = 0; w < wordboxes.length; w++) {
-      pdfFile.rect(wordboxes[w][0],wordboxes[w][1],
+      pdfDoc.rect(wordboxes[w][0],wordboxes[w][1],
                   wordboxes[w][2],wordboxes[w][3])
             .strokeColor('#ADD8E6')
             .fillColor('#ADD8E6')
@@ -68,10 +68,10 @@ sharp(fs.readFileSync(imageFile))
             .fillOpacity(1)
             .stroke()
     }
-    
-    var paraboxes = newFile.drawParagraphBoxes()
+
+    var paraboxes = hocrObj.drawParagraphBoxes()
     for (var p = 0; p < paraboxes.length; p++) {
-      pdfFile.rect(paraboxes[p][0],paraboxes[p][1],
+      pdfDoc.rect(paraboxes[p][0],paraboxes[p][1],
                   paraboxes[p][2],paraboxes[p][3])
             .strokeColor('#90EE90')
             .lineWidth(0.5)
@@ -80,13 +80,13 @@ sharp(fs.readFileSync(imageFile))
             .dash(6, {space: 3})
             .stroke()
     }
-    
-    pdfFile.image(data, 0, 0, {
-      fit: [newFile.width, newFile.height]
+
+    pdfDoc.image(data, 0, 0, {
+      fit: [hocrObj.width, hocrObj.height]
     })
-    
+
     // finalise the PDF
-    doc.end()
+    pdfDoc.end()
   }
 )
 //thats it.


### PR DESCRIPTION
I know this is 8-year-old code you aren't looking to maintain!

But I'm finding it useful as a readable example of at least a basic HOCR renderer -- I can't find many others!

The example in the README had inconsistent variable names, fixed them to make the example succesfully runnable. 

Merge if you want, but otherwise this PR can still be here for anyone else that comes along! 

Thank you! 