### PR TITLE
Specify dependencies that work in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "cheerio": "^0.19.0",
+    "cheerio": ">=0.19.0 <=1.0.0-rc.6",
+    "pdfkit": "",
+    "sharp": ""
   },
   "engines": {
     "node": ">=0.12.0"


### PR DESCRIPTION
I discovered that current code does not work with cheerio > 1.0.0-rc.6.  It's possible it wouldn't take much changes to make it work, but just documenting what works.

As long as I'm at it, list the other dependencies mentioned in README.

(Again, feel free to merge, or ignore; this can serve as notice to others looking to try out the code). 